### PR TITLE
SuperSimpleShell Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /.idea/
 /CMakeLists.txt
 /testRun
-
+supersimp
 snewbytest
 11-lists
 /hbtn_ls

--- a/supersimp.c
+++ b/supersimp.c
@@ -10,14 +10,15 @@
 #include <stdarg.h>
 typedef struct path_s {
 	char *directory;
-	//unsigned int len;
-	struct node_s *next;
+	struct path_s *next;
 } path_t;
 
 extern char **environ;
 char *_getenv(const char *name);
 void printPATH(void);
 path_t *buildListPath(void);
+int _setenv(const char *name, const char *value, int overwrite);
+int _unsetenv(const char *name);
 
 int main(int argc, char *argv[], char **env)
 {
@@ -63,7 +64,7 @@ void printPATH()
 path_t *buildListPath(void)
 {
 	path_t *new_node = NULL;
-	path_t *head;
+	path_t *head = NULL;
 	char *path = getenv("PATH");
 	char *token = strtok(path, ":");
 
@@ -78,4 +79,60 @@ path_t *buildListPath(void)
 		token = strtok(NULL, ":");
 	}
 	return (head);
+}
+
+/**
+ * _setenv - sets an environmental variable to a new value, or appends a new value if not found
+ * @name: name of environmental variable to be set
+ * @value: value to set the environmental variable to
+ * @overwrite: nonzero to actually change the value, zero to not change
+ *
+ * Return: 0 on success, -1 on failure
+ */
+int _setenv(const char *name, const char *value, int overwrite)
+{
+	int i;
+	char *temp;
+	char *new_line;
+	char found = -1; /* flag for finding name, 0 if found */
+	int size_environ = 0;
+
+	if (name == NULL)
+		return(-1);
+	else if (strlen(name) == 0 || strchr(name, '=') == NULL)
+		return (-1);
+
+	new_line = malloc(strlen(name) + strlen(value) + 2); /* line */
+	if (new_line == NULL)
+		return (-1);
+	strcpy(new_line, name);
+	strcat(new_line, "=");
+	strcat(new_line, value);
+
+	for (i = 0; environ[i] != NULL && overwrite != 0; i++)
+	{
+		temp = strtok(environ[i], "=");
+		size_environ += strlen(environ[i]);
+
+		if (strcmp(temp, name) == 0) /* name found in environ */
+		{
+			free(environ[i]); /* does this work? */
+			environ[i] = strdup(new_line);
+			found = 0;
+			break;
+		}
+	}
+	if (found != 0 && overwrite != 0 && environ[i] == NULL)
+	{ /* currently assumes environ can be modified. if not, will need to rebuild it.*/
+		environ = realloc(environ, size_environ + strlen(new_line));
+		if (environ == NULL)
+		{
+			free(new_line);
+			return (-1);
+		}
+		environ[i] = strdup(new_line);
+	}
+
+	free(new_line);
+	return (0);
 }

--- a/supersimp.c
+++ b/supersimp.c
@@ -102,27 +102,27 @@ int _setenv(const char *name, const char *value, int overwrite)
 	else if (strlen(name) == 0 || strchr(name, '=') == NULL)
 		return (-1);
 
-	new_line = malloc(strlen(name) + strlen(value) + 2); /* line */
+	new_line = malloc(strlen(name) + strlen(value) + 2); /* line replacement */
 	if (new_line == NULL)
 		return (-1);
 	strcpy(new_line, name);
 	strcat(new_line, "=");
 	strcat(new_line, value);
 
-	for (i = 0; environ[i] != NULL && overwrite != 0; i++)
+	for (i = 0; environ[i] != NULL && overwrite != 0; i++) /* looks for name */
 	{
 		temp = strtok(environ[i], "=");
 		size_environ += strlen(environ[i]);
 
 		if (strcmp(temp, name) == 0) /* name found in environ */
 		{
-			free(environ[i]); /* does this work? */
+			free(environ[i]);
 			environ[i] = strdup(new_line);
 			found = 0;
 			break;
 		}
 	}
-	if (found != 0 && overwrite != 0 && environ[i] == NULL)
+	if (found != 0 && overwrite != 0 && environ[i] == NULL) /* if at end */
 	{ /* currently assumes environ can be modified. if not, will need to rebuild it.*/
 		environ = realloc(environ, size_environ + strlen(new_line));
 		if (environ == NULL)


### PR DESCRIPTION
# July 22nd 11:17am

-Mostly finished _setenv
 - still needs debugging 
 - added comments for clarity
 

-  setenv and _unsetenv are supposed to modify the external variable environ. environ is an array of strings that we can (1) if not const in our system, modify directly by reallocing it at the proper location with edits, (2) build a copy of the environ variable using strdup a lot and adjusting the proper location, and then point environ at the new array after freeing the previous array, (3) doing either of the above but with linked lists instead of the array, and then rebuilding into an array.
 - option 1 is current version