### PR TITLE
moved command-existence check

### DIFF
--- a/env.c
+++ b/env.c
@@ -12,6 +12,9 @@ char *_getenv(const char *name) /* gets an environmental variable */
 	char *token;
 	char *temp_line;
 	char *temp = NULL;
+
+	if (environ == NULL)
+		return (NULL);
 	for (current = environ; *current; current++)
 	{
 		temp_line = strdup(*current);

--- a/shell_loop.c
+++ b/shell_loop.c
@@ -16,7 +16,7 @@ void shellLoop(char *argv[])
 	int tokens_count;
 	char *cmd;
 	char *paths[1] = {NULL};
-	int custom_cmd_rtn, getline_rtn;
+	int custom_cmd_rtn, getline_rtn, run_cmd_rtn;
 	int i;
 
 	while (1)
@@ -99,14 +99,9 @@ void shellLoop(char *argv[])
 		/* run command; if child process fails, stop the child process from re-entering loop */
 		if (custom_cmd_rtn == 0) /* input is not a custom command */
 		{
-			if (access(cmd, F_OK) != 0) /* checks if cmd doesn't exists */
-			{
-				/* print error message in a specific format */
-				fprintf(stderr, "%s: 1: %s: %s\n", argv[0], cmd, strerror(errno));
-				freeAll(tokens, cmd, input, NULL);
-				continue; /* go back to start of the loop */
-			}
-			runCommand(cmd, tokens, paths); /* runs the command otherwise */
+			run_cmd_rtn = runCommand(cmd, tokens, paths); /* runs the command otherwise */
+			if (run_cmd_rtn != 0)
+				fprintf(stderr, "%s: 1: %s: %s\n", argv[0], cmd, strerror(run_cmd_rtn));
 		}
 		freeAll(tokens, cmd, input, NULL);
 	}
@@ -175,6 +170,8 @@ int runCommand(char *commandPath, char **args, char **envPaths)
 	int exec_rtn = 0, child_status;
 	pid_t fork_rtn, wait_rtn;
 
+	if (access(commandPath, F_OK) != 0) /* checks if cmd doesn't exists */
+		return(127);
 	fork_rtn = fork(); /* split process into 2 processes */
 	if (fork_rtn == -1) /* Fork! It failed */
 	{


### PR DESCRIPTION
# July 24th 6:17pm

- moved command-existence code into runCommand
- adjusted the fprintf error message to handle the change
- consider: may need to rewrite error messages from runCommand
- consider: may need to have runCommand and customCmd work with isatty() to exit instead of return when in noninteractive mode